### PR TITLE
让国际化不区分大小写

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ export default {
   port: 5678, //service start port
   protocol: 'http', //domain protocol
   token: 'TOKEN_VALUE', //token to check before every operation
-  website_title: 'welefen\'s favorites' //site's title
+  website_title: 'welefen\'s favorites', //site's title
+  visibility: 'public'  //set private to check token before view articles
 };
 ```
 

--- a/src/common/bootstrap/middleware.js
+++ b/src/common/bootstrap/middleware.js
@@ -11,3 +11,22 @@
  * })
  * 
  */
+
+'use strict';
+
+let locale = think.config('locale'), acceptLanguages, acceptLanguagesLowerCase;
+if(locale){ 
+  acceptLanguages = Object.keys(locale);
+  acceptLanguagesLowerCase = acceptLanguages.map((o) => o.toLowerCase());
+}
+
+think.middleware("check_lang", http => {  
+  if(acceptLanguages){
+    let lang = http.header('accept-language');
+    lang = lang.split(',')[0];
+    let idx = acceptLanguagesLowerCase.indexOf(lang);
+    if(idx >= 0){
+      http.lang(acceptLanguages[idx]);
+    } 
+  }
+});

--- a/src/common/config/config.js
+++ b/src/common/config/config.js
@@ -6,6 +6,6 @@ export default {
   port: 5678, //service start port
   protocol: 'http', //domain protocol
   token: 'TOKEN_VALUE', //token to check before every operation
-  website_title: 'website-title',
-  visibility: 'public'
+  website_title: 'website-title', //site's title
+  visibility: 'public' //set private to check token before view articles
 };

--- a/src/common/config/hook.js
+++ b/src/common/config/hook.js
@@ -5,5 +5,5 @@
  * https://thinkjs.org/doc/middleware.html#toc-df6
  */
 export default {
-
+  view_template: ['prepend', 'check_lang'],
 }


### PR DESCRIPTION
ThinkJS的国际化区分大小写，所以zh-cn和zh-CN对应不同的路径，实际上很多服务发送的语言请求头是不区分大小写的，建议ThinkJS中进行修改，本系统先通过MiddleWare来解决这一问题。
