### PR TITLE
Fix Sqlite3 Warning: db.name is deprecated, use db.database instead

### DIFF
--- a/src/common/config/db.js
+++ b/src/common/config/db.js
@@ -5,7 +5,7 @@
  */
 export default {
   type: 'sqlite',
-  name: 'cicada',
+  database: 'cicada',
   prefix: 'ci_',
   encoding: 'utf8',
   nums_per_page: 10,


### PR DESCRIPTION
sqlite3@^3.1.1:
  version "3.1.13"
  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
  dependencies:
    nan "~2.7.0"
    node-pre-gyp "~0.6.38"

修复一直提示的 Warning